### PR TITLE
Handle seconds and minutes better

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,9 @@ import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
     let disposable = vscode.commands.registerCommand('extension.openJunkfile', () => {
         const date = new Date();
-        const junkPath = date.getFullYear() + '/' + (date.getMonth() + 1) + '/' + date.getDate() + '-' +
-                         date.getHours().toString() + date.getMinutes().toString() + date.getSeconds().toString() + '.';
+        const minutes = date.getMinutes() < 10 ? `0${date.getMinutes()}` : `${date.getMinutes()}`
+        const seconds = date.getSeconds() < 10 ? `0${date.getSeconds()}` : `${date.getSeconds()}`
+        const junkPath = `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}-${date.getHours()}h${minutes}m${seconds}s.`;
         const pathLength = junkPath.length                         
 
         vscode.window.showInputBox({


### PR DESCRIPTION
Hi, first of all thanks for your extension, this is very handy.
Now the extension doesn't show the zeros for minutes and seconds inferior to 10, this is confusing.
Here is my take:

Thanks